### PR TITLE
Added temporary attack and temporary life

### DIFF
--- a/client/CMCComponents/Card.tsx
+++ b/client/CMCComponents/Card.tsx
@@ -190,15 +190,16 @@ function CMCCardVisual({
     );
   }
   if (card.type == CardType.MONSTER) {
+    const monsterCard = (cardObject as CMCMonsterCard);
     attackLine = (
       <div className="attackline">
         <div className="attack">
           {icons.sword}
-          {(cardObject as CMCMonsterCard).attack}
+          {monsterCard.attack + (monsterCard.temporaryAttack ?? 0)}
         </div>
         <div className="life">
           {icons.life}
-          <span className="curlife">{(cardObject as CMCMonsterCard).life}</span>
+          <span className="curlife">{monsterCard.life + (monsterCard.temporaryLife ?? 0)}</span>
         </div>
       </div>
     );

--- a/client/Pages/CardImporter.tsx
+++ b/client/Pages/CardImporter.tsx
@@ -45,6 +45,8 @@ const Importer = () => {
               ...newCard,
               attack: record.attack,
               life: record.life,
+              temporaryAttack: 0,
+              temporaryLife: 0,
               dizzy: true,
               destroyed: false,
               status: {},

--- a/shared/CMCCard.ts
+++ b/shared/CMCCard.ts
@@ -97,7 +97,9 @@ interface CMCEntityCard extends CMCCard {
 interface CMCEffectCard extends CMCEntityCard {}
 interface CMCMonsterCard extends CMCEntityCard {
   attack: number;
+  temporaryAttack: number;
   life: number;
+  temporaryLife: number;
 }
 
 interface CMCPersonaCard extends CMCCard {
@@ -165,7 +167,9 @@ function CreateEntityCard(): CMCEntityCard {
 function CreateMonsterCard(): CMCMonsterCard {
   const card: CMCMonsterCard = {
     life: 0,
+    temporaryLife: 0,
     attack: 0,
+    temporaryAttack: 0,
     ...CreateEntityCard(),
   };
   card.type = CardType.MONSTER;

--- a/shared/CMCCombat.ts
+++ b/shared/CMCCombat.ts
@@ -87,6 +87,7 @@ function ResolveCombat(
       G,
       ctx
     ) as CMCMonsterCard;
+    modatk.attack += modatk.temporaryAttack;
     // phase zero, trigger
     // check if card is dead yet
     if (resolution.attacker.destroyed) {
@@ -121,6 +122,8 @@ function ResolveCombat(
         G,
         ctx
       ) as CMCMonsterCard;
+      moddef.attack += moddef.temporaryAttack;
+
       let dresult: DamageResult = DealDamage(
         resolution.attacker,
         resolution.defender,
@@ -128,7 +131,7 @@ function ResolveCombat(
         G
       );
       resolvedatk.damage = dresult.damage;
-      resolvedatk.destroyed = resolution.attacker.life <= 0;
+      resolvedatk.destroyed = dresult.destroyed;
       resolvedatk.overage = dresult.overage;
       resolvedatk.resisted = 0;
 
@@ -144,7 +147,7 @@ function ResolveCombat(
       );
 
       resolveddef.damage = dresult.damage;
-      resolveddef.destroyed = resolution.defender.life <= 0;
+      resolveddef.destroyed = dresult.destroyed
       resolveddef.overage = dresult.overage;
       resolveddef.resisted = 0;
     }

--- a/shared/CardFunctions.ts
+++ b/shared/CardFunctions.ts
@@ -27,6 +27,7 @@ import {
   DrawCard,
   ForceDiscard,
   GainLife,
+  GainTemporaryStats,
   IsEffect,
   IsMonster,
   IsPersona,
@@ -247,6 +248,28 @@ export function ApplyStats(args: AbilityFunctionArgs): Targets {
       realtargets.push(target);
     }
   }
+  return realtargets;
+}
+
+
+export function TemporaryStatGain(args: AbilityFunctionArgs): Targets {
+  const { target, card, ability, G } = args;
+  if (!ability ) {
+    return [];
+  }
+  const targets: CMCCard[] = ValidTargets(args, AllCards(G).allinplay);
+  const realtargets: CMCCard[] = [];
+  for (const target of targets) {
+
+    if (IsMonster(target)) {
+      GainTemporaryStats(target, ability.metadata.lifeAmount, ability.metadata.attackAmount, G);
+      realtargets.push(target);
+    } else {
+      console.error("isnt monster");
+      continue;
+    }
+  }
+
   return realtargets;
 }
 

--- a/shared/Moves.ts
+++ b/shared/Moves.ts
@@ -34,6 +34,7 @@ import {
   ForceDiscard,
   Discard,
   Undizzy,
+  RemoveTemporaryStats
 } from "./LogicFunctions";
 import { CMCPlayer } from "./Player";
 import { GetActivePlayer, GetActiveStage, OtherPlayer } from "./Util";
@@ -76,6 +77,7 @@ const passStage: Move<CMCGameState> = ({ G, ctx, events, random }) => {
   if (GetActiveStage(ctx) == Stages.initial) {
     // going into draw phase
     const player: CMCPlayer = G.playerData[activePlayer];
+    RemoveTemporaryStats(activePlayer, G, ctx);
     const okay = DrawCard(
       activePlayer,
       player.persona.drawPerTurn,

--- a/shared/data/cards.json
+++ b/shared/data/cards.json
@@ -243,9 +243,11 @@
         }
       },
       "abilities": [],
-      "attack": "1",
-      "life": "1",
+      "attack": 1,
+      "life": 1,
       "dizzy": true,
+      "temporaryAttack": 0,
+      "temporaryLife": 0,
       "destroyed": false,
       "status": {}
     },
@@ -278,6 +280,8 @@
       "attack": "5",
       "life": "5",
       "dizzy": true,
+      "temporaryAttack": 0,
+      "temporaryLife": 0,
       "destroyed": false,
       "status": {}
     },
@@ -323,6 +327,8 @@
       "attack": "10",
       "life": "10",
       "dizzy": true,
+      "temporaryAttack": 0,
+      "temporaryLife": 0,
       "destroyed": false,
       "status": {}
     },
@@ -367,6 +373,8 @@
       "attack": "15",
       "life": "15",
       "dizzy": true,
+      "temporaryAttack": 0,
+      "temporaryLife": 0,
       "destroyed": false,
       "status": {}
     },
@@ -419,6 +427,8 @@
       "attack": "20",
       "life": "20",
       "dizzy": true,
+      "temporaryAttack": 0,
+      "temporaryLife": 0,
       "destroyed": false,
       "status": {}
     },
@@ -426,6 +436,8 @@
       "life": 10,
       "attack": 10,
       "dizzy": true,
+      "temporaryAttack": 0,
+      "temporaryLife": 0,
       "status": {},
       "destroyed": false,
       "alignment": "ANODYNE",
@@ -517,6 +529,8 @@
       "attack": "20",
       "life": "20",
       "dizzy": true,
+      "temporaryAttack": 0,
+      "temporaryLife": 0,
       "destroyed": false,
       "status": {}
     },
@@ -558,6 +572,8 @@
       "attack": "45",
       "life": "45",
       "dizzy": true,
+      "temporaryAttack": 0,
+      "temporaryLife": 0,
       "destroyed": false,
       "status": {}
     },
@@ -626,6 +642,8 @@
       "attack": "60",
       "life": "60",
       "dizzy": true,
+      "temporaryAttack": 0,
+      "temporaryLife": 0,
       "destroyed": false,
       "status": {}
     },
@@ -667,6 +685,8 @@
       "attack": "0",
       "life": "60",
       "dizzy": true,
+      "temporaryAttack": 0,
+      "temporaryLife": 0,
       "destroyed": false,
       "status": {}
     },
@@ -710,6 +730,8 @@
       "attack": "30",
       "life": "30",
       "dizzy": true,
+      "temporaryAttack": 0,
+      "temporaryLife": 0,
       "destroyed": false,
       "status": {}
     },
@@ -751,6 +773,8 @@
       "attack": "15",
       "life": "15",
       "dizzy": true,
+      "temporaryAttack": 0,
+      "temporaryLife": 0,
       "destroyed": false,
       "status": {}
     },
@@ -796,6 +820,8 @@
       "attack": "20",
       "life": "20",
       "dizzy": true,
+      "temporaryAttack": 0,
+      "temporaryLife": 0,
       "destroyed": false,
       "status": {}
     },
@@ -847,6 +873,8 @@
       "attack": "1",
       "life": "20",
       "dizzy": true,
+      "temporaryAttack": 0,
+      "temporaryLife": 0,
       "destroyed": false,
       "status": {}
     },
@@ -890,6 +918,8 @@
       "attack": "40",
       "life": "40",
       "dizzy": true,
+      "temporaryAttack": 0,
+      "temporaryLife": 0,
       "destroyed": false,
       "status": {}
     },
@@ -943,6 +973,8 @@
       "attack": "40",
       "life": "40",
       "dizzy": true,
+      "temporaryAttack": 0,
+      "temporaryLife": 0,
       "destroyed": false,
       "status": {}
     },
@@ -992,6 +1024,8 @@
       "attack": "30",
       "life": "30",
       "dizzy": true,
+      "temporaryAttack": 0,
+      "temporaryLife": 0,
       "destroyed": false,
       "status": {}
     },
@@ -2014,6 +2048,8 @@
       "attack": "15",
       "life": "7",
       "dizzy": true,
+      "temporaryAttack": 0,
+      "temporaryLife": 0,
       "destroyed": false,
       "status": {}
     },
@@ -2046,6 +2082,8 @@
       "attack": "",
       "life": "",
       "dizzy": true,
+      "temporaryAttack": 0,
+      "temporaryLife": 0,
       "destroyed": false,
       "status": {}
     },
@@ -2078,6 +2116,8 @@
       "attack": "",
       "life": "",
       "dizzy": true,
+      "temporaryAttack": 0,
+      "temporaryLife": 0,
       "destroyed": false,
       "status": {}
     },
@@ -2110,6 +2150,8 @@
       "attack": "",
       "life": "",
       "dizzy": true,
+      "temporaryAttack": 0,
+      "temporaryLife": 0,
       "destroyed": false,
       "status": {}
     },
@@ -2142,6 +2184,8 @@
       "attack": "",
       "life": "",
       "dizzy": true,
+      "temporaryAttack": 0,
+      "temporaryLife": 0,
       "destroyed": false,
       "status": {}
     },
@@ -2174,6 +2218,8 @@
       "attack": "",
       "life": "",
       "dizzy": true,
+      "temporaryAttack": 0,
+      "temporaryLife": 0,
       "destroyed": false,
       "status": {}
     },
@@ -2206,6 +2252,8 @@
       "attack": "",
       "life": "",
       "dizzy": true,
+      "temporaryAttack": 0,
+      "temporaryLife": 0,
       "destroyed": false,
       "status": {}
     },
@@ -2238,6 +2286,8 @@
       "attack": "",
       "life": "",
       "dizzy": true,
+      "temporaryAttack": 0,
+      "temporaryLife": 0,
       "destroyed": false,
       "status": {}
     },
@@ -2270,6 +2320,8 @@
       "attack": "",
       "life": "",
       "dizzy": true,
+      "temporaryAttack": 0,
+      "temporaryLife": 0,
       "destroyed": false,
       "status": {}
     },
@@ -2302,6 +2354,8 @@
       "attack": "",
       "life": "",
       "dizzy": true,
+      "temporaryAttack": 0,
+      "temporaryLife": 0,
       "destroyed": false,
       "status": {}
     },
@@ -2334,6 +2388,8 @@
       "attack": "",
       "life": "",
       "dizzy": true,
+      "temporaryAttack": 0,
+      "temporaryLife": 0,
       "destroyed": false,
       "status": {}
     },
@@ -2366,6 +2422,8 @@
       "attack": "",
       "life": "",
       "dizzy": true,
+      "temporaryAttack": 0,
+      "temporaryLife": 0,
       "destroyed": false,
       "status": {}
     },
@@ -2398,6 +2456,8 @@
       "attack": "",
       "life": "",
       "dizzy": true,
+      "temporaryAttack": 0,
+      "temporaryLife": 0,
       "destroyed": false,
       "status": {}
     },
@@ -2430,6 +2490,8 @@
       "attack": "",
       "life": "",
       "dizzy": true,
+      "temporaryAttack": 0,
+      "temporaryLife": 0,
       "destroyed": false,
       "status": {}
     },
@@ -2462,6 +2524,8 @@
       "attack": "",
       "life": "",
       "dizzy": true,
+      "temporaryAttack": 0,
+      "temporaryLife": 0,
       "destroyed": false,
       "status": {}
     },
@@ -2494,6 +2558,8 @@
       "attack": "",
       "life": "",
       "dizzy": true,
+      "temporaryAttack": 0,
+      "temporaryLife": 0,
       "destroyed": false,
       "status": {}
     },
@@ -2526,6 +2592,8 @@
       "attack": "",
       "life": "",
       "dizzy": true,
+      "temporaryAttack": 0,
+      "temporaryLife": 0,
       "destroyed": false,
       "status": {}
     },
@@ -2558,6 +2626,8 @@
       "attack": "",
       "life": "",
       "dizzy": true,
+      "temporaryAttack": 0,
+      "temporaryLife": 0,
       "destroyed": false,
       "status": {}
     },
@@ -3069,6 +3139,8 @@
       "attack": "",
       "life": "",
       "dizzy": true,
+      "temporaryAttack": 0,
+      "temporaryLife": 0,
       "destroyed": false,
       "status": {}
     },
@@ -3101,6 +3173,8 @@
       "attack": "",
       "life": "",
       "dizzy": true,
+      "temporaryAttack": 0,
+      "temporaryLife": 0,
       "destroyed": false,
       "status": {}
     },
@@ -3133,6 +3207,8 @@
       "attack": "",
       "life": "",
       "dizzy": true,
+      "temporaryAttack": 0,
+      "temporaryLife": 0,
       "destroyed": false,
       "status": {}
     },
@@ -3165,6 +3241,8 @@
       "attack": "",
       "life": "",
       "dizzy": true,
+      "temporaryAttack": 0,
+      "temporaryLife": 0,
       "destroyed": false,
       "status": {}
     },
@@ -3197,6 +3275,8 @@
       "attack": "",
       "life": "",
       "dizzy": true,
+      "temporaryAttack": 0,
+      "temporaryLife": 0,
       "destroyed": false,
       "status": {}
     },
@@ -3229,6 +3309,8 @@
       "attack": "",
       "life": "",
       "dizzy": true,
+      "temporaryAttack": 0,
+      "temporaryLife": 0,
       "destroyed": false,
       "status": {}
     },
@@ -3261,6 +3343,8 @@
       "attack": "",
       "life": "",
       "dizzy": true,
+      "temporaryAttack": 0,
+      "temporaryLife": 0,
       "destroyed": false,
       "status": {}
     },
@@ -3293,6 +3377,8 @@
       "attack": "",
       "life": "",
       "dizzy": true,
+      "temporaryAttack": 0,
+      "temporaryLife": 0,
       "destroyed": false,
       "status": {}
     },
@@ -3325,6 +3411,8 @@
       "attack": "",
       "life": "",
       "dizzy": true,
+      "temporaryAttack": 0,
+      "temporaryLife": 0,
       "destroyed": false,
       "status": {}
     },
@@ -3357,6 +3445,8 @@
       "attack": "",
       "life": "",
       "dizzy": true,
+      "temporaryAttack": 0,
+      "temporaryLife": 0,
       "destroyed": false,
       "status": {}
     },
@@ -3389,6 +3479,8 @@
       "attack": "",
       "life": "",
       "dizzy": true,
+      "temporaryAttack": 0,
+      "temporaryLife": 0,
       "destroyed": false,
       "status": {}
     },
@@ -3421,6 +3513,8 @@
       "attack": "",
       "life": "",
       "dizzy": true,
+      "temporaryAttack": 0,
+      "temporaryLife": 0,
       "destroyed": false,
       "status": {}
     },
@@ -4005,6 +4099,8 @@
       "attack": "",
       "life": "",
       "dizzy": true,
+      "temporaryAttack": 0,
+      "temporaryLife": 0,
       "destroyed": false,
       "status": {}
     },
@@ -4037,6 +4133,8 @@
       "attack": "",
       "life": "",
       "dizzy": true,
+      "temporaryAttack": 0,
+      "temporaryLife": 0,
       "destroyed": false,
       "status": {}
     },
@@ -4069,6 +4167,8 @@
       "attack": "",
       "life": "",
       "dizzy": true,
+      "temporaryAttack": 0,
+      "temporaryLife": 0,
       "destroyed": false,
       "status": {}
     },
@@ -4101,6 +4201,8 @@
       "attack": "",
       "life": "",
       "dizzy": true,
+      "temporaryAttack": 0,
+      "temporaryLife": 0,
       "destroyed": false,
       "status": {}
     },
@@ -4400,6 +4502,130 @@
         }
       },
       "abilities": []
+    },    
+    "TemporaryAttackDebugSpell": {
+      "alignment": "ANODYNE",
+      "guid": "TEMPORARY",
+      "subtype": "",
+      "costFunction": "DefaultCost",
+      "playFunction": "DefaultPlay",
+      "name": "tempAttack",
+      "picture": "placeholder.jpg",
+      "cardtext": "Grant monster 10 temporary attack",
+      "type": "SPELL",
+      "sac": {
+        "mana": {
+          "V": 0,
+          "A": 0,
+          "P": 0
+        }
+      },
+      "cost": {
+        "mana": {
+          "V": 0,
+          "A": 1,
+          "P": 0
+        }
+      },
+      "abilities": [
+        {
+          "triggerType": "ACTIVATED_TARGETED",
+          "targetCode": "IsDamagable",
+          "activateCode": "TemporaryStatGain",
+          "metadata": {
+            "lifeAmount": 0,
+            "attackAmount":10
+          },
+          "abilityName": "tempAttack",
+          "abilityText": "Grant monster 10 temporary attack",
+          "speed": 2
+        }
+      ],
+      "expansion": "base"
+    },
+    "TemporaryLifeDebugSpell": {
+      "alignment": "ANODYNE",
+      "guid": "TEMPORARY",
+      "subtype": "",
+      "costFunction": "DefaultCost",
+      "playFunction": "DefaultPlay",
+      "name": "tempLife",
+      "picture": "placeholder.jpg",
+      "cardtext": "Grant monster 10 temporary life",
+      "type": "SPELL",
+      "sac": {
+        "mana": {
+          "V": 0,
+          "A": 0,
+          "P": 0
+        }
+      },
+      "cost": {
+        "mana": {
+          "V": 0,
+          "A": 1,
+          "P": 0
+        }
+      },
+      "abilities": [
+        {
+          "triggerType": "ACTIVATED_TARGETED",
+          "targetCode": "IsDamagable",
+          "activateCode": "TemporaryStatGain",
+          "metadata": {
+            "lifeAmount": 10,
+            "attackAmount":0
+          },
+          "abilityName": "tempLife",
+          "abilityText": "Grant monster 10 temporary life",
+          "speed": 2
+        }
+      ],
+      "expansion": "base"
+    },
+    "TemporaryStatsDebugSpell": {
+      "alignment": "ANODYNE",
+      "guid": "TEMPORARY",
+      "subtype": "",
+      "costFunction": "DefaultCost",
+      "playFunction": "DefaultPlay",
+      "name": "tempLifeAndAttack",
+      "picture": "placeholder.jpg",
+      "cardtext": "Grant monster 10 temporary life & 10 temporary attack",
+      "type": "SPELL",
+      "sac": {
+        "mana": {
+          "V": 0,
+          "A": 0,
+          "P": 0
+        }
+      },
+      "cost": {
+        "mana": {
+          "V": 0,
+          "A": 1,
+          "P": 0
+        }
+      },
+      "abilities": [
+        {
+          "triggerType": "ACTIVATED_TARGETED",
+          "targetCode": "Match",
+          "activateCode": "TemporaryStatGain",
+          "metadata": {
+            "lifeAmount": 20,
+            "attackAmount":20,
+            "matchPattern": {
+              "type": "MONSTER"
+            }
+          },
+          "abilityName": "tempLifeAndAttack",
+          "abilityText": "Grant monster 10 temporary life & 10 temporary attack",
+          "speed": 2
+        }
+      ],
+      "expansion": "base"
     }
+
   }
 }


### PR DESCRIPTION
These changes were entirely experimental while i was learning the codebase and might not be the direction we want to game to go so feel free to have this pull request abandoned. It was just done as quick side project while i was looking around at stuff and getting the game work locally. I have tested it all with the new temp stats cards i added though so if you'd like this feature, it's working.

These changes added a new temporary attack and temporary life stat alongside the normal attack and life. Temporary stats are lost after the turn ends and reset to 0. Cards start with 0 in both temp stats however there is room to expand this by editing the cards.json if we want cards that start with temp stats.

When calculating damage i've changed it so that it now takes off the temporary life before doing the life. I also updated it so that the destroyed flag is calculated as part of damageResult so we dont have to calculate it multiple times.

