### PR TITLE
Added delete deck functionality

### DIFF
--- a/client/Pages/DeckChooser.tsx
+++ b/client/Pages/DeckChooser.tsx
@@ -34,7 +34,7 @@ const DeckChooser = () => {
         setfetchflag(!fetchflag);
       });
     } else {
-      nav("/decks/" + deckid);
+      nav("/decks/" + deckid, { state: DbPlayer.selecteddeck });
     }
   }
   function selectdeck(deckid: string) {

--- a/client/Pages/DeckEditor.tsx
+++ b/client/Pages/DeckEditor.tsx
@@ -239,23 +239,23 @@ const DeckEditor = ({ deckid }: { deckid: string }) => {
         </div>
         <div className="deckEditorInner">
           <div className="deckEditorTopBanner">
-          <div className="deckname">
-            <input
+            <input className="deckName"
               type="text"
               name="deckname"
               onChange={handletextchange}
               value={FullDeck.deck.deckname}
             />
-            <button
+          <div style={{display:"inline-block"}}>
+          <button className="deckEditorButton"
               onClick={() => {
                 savedeck();
               }}
             >
-              SAVE
+              Save
             </button>
           </div>
           <div className="deleteDeck" title ={canDeleteDeck ? "" : "Unable to delete as its your current main deck"}>
-            <button
+            <button className="deckEditorButton"
                 onClick={() => {
                   if (confirm("Are you sure you want to delete this deck?"))
                   {

--- a/client/Pages/DeckEditor.tsx
+++ b/client/Pages/DeckEditor.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams, useLocation } from "react-router-dom";
 import {
   DbDeck,
   DbDeckCard,
@@ -48,7 +48,6 @@ const DeckEditor = ({ deckid }: { deckid: string }) => {
     newDeck.deck.deckicon = icon;
     setFullDeck(newDeck);
   };
-
   const nav = useNavigate();
   const savedeck = () => {
     console.log("Saving deck");
@@ -67,6 +66,25 @@ const DeckEditor = ({ deckid }: { deckid: string }) => {
           nav("/decks");
         } else {
           console.error("Couldnt save deck");
+        }
+      });
+  };
+  const deleteDeck = () => {
+    console.log("Deleting deck");
+    // save deck
+    const requestOptions = {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+    };
+    fetch("/api/manage/decks/delete/" + FullDeck.deck.deckid, requestOptions)
+      .then((response) => response.json())
+      .then((data) => {
+        console.log(data);
+        if (data.success) {
+          // nav back to decks
+          nav("/decks");
+        } else {
+          console.error("Couldnt delete deck");
         }
       });
   };
@@ -198,6 +216,7 @@ const DeckEditor = ({ deckid }: { deckid: string }) => {
   const player = CreateDefaultPlayer(PlayerID);
   player.name = FullDeck.deck.deckname;
   const Genericplayer = CreateDefaultPlayer(PlayerID);
+  const canDeleteDeck = useLocation().state != FullDeck.deck.deckid;
   Genericplayer.name = "";
   if (Loading) {
     return <div className="loading">Loading</div>;
@@ -218,7 +237,8 @@ const DeckEditor = ({ deckid }: { deckid: string }) => {
             );
           })}
         </div>
-        <div className="personapicker">
+        <div className="deckEditorInner">
+          <div className="deckEditorTopBanner">
           <div className="deckname">
             <input
               type="text"
@@ -234,41 +254,58 @@ const DeckEditor = ({ deckid }: { deckid: string }) => {
               SAVE
             </button>
           </div>
-          <div className="currentpersona">
-            <div className="currentpersonabox">
-              <CMCCardVisual
-                card={GetCardPrototype(FullDeck.deck.persona)}
-                big={true}
-                canClick={true}
-                doClick={() => {}}
-                activeCard={false}
-                player={player}
-                showplayer={false}
-              />
-              <div className="deckicon">{icons[FullDeck.deck.deckicon]}</div>
+          <div className="deleteDeck" title ={canDeleteDeck ? "" : "Unable to delete as its your current main deck"}>
+            <button
+                onClick={() => {
+                  if (confirm("Are you sure you want to delete this deck?"))
+                  {
+                    deleteDeck();
+                  }
+                }}
+                style={!canDeleteDeck ? {pointerEvents: "none"} : {}}
+                disabled = {!canDeleteDeck}
+              >
+                Delete deck <span style={ canDeleteDeck ? {color: "red"} : {}}> X </span>
+              </button>
+
             </div>
           </div>
-          <div className="ownedpersonalist">
-            {personas.map((deckcard) => {
-              return (
-                <div className="deckcardvisual">
-                  <CMCCardVisual
-                    card={GetCardPrototype(deckcard.cardid)}
-                    big={true}
-                    canClick={true}
-                    doClick={() => {
-                      selectpersona(deckcard.cardid);
-                    }}
-                    activeCard={false}
-                    player={Genericplayer}
-                    showplayer={false}
-                  />
-                </div>
-              );
-            })}
+          <div className="personapicker">
+            <div className="currentpersona">
+              <div className="currentpersonabox">
+                <CMCCardVisual
+                  card={GetCardPrototype(FullDeck.deck.persona)}
+                  big={true}
+                  canClick={true}
+                  doClick={() => {}}
+                  activeCard={false}
+                  player={player}
+                  showplayer={false}
+                />
+                <div className="deckicon">{icons[FullDeck.deck.deckicon]}</div>
+              </div>
+            </div>
+            <div className="ownedpersonalist">
+              {personas.map((deckcard) => {
+                return (
+                  <div className="deckcardvisual">
+                    <CMCCardVisual
+                      card={GetCardPrototype(deckcard.cardid)}
+                      big={true}
+                      canClick={true}
+                      doClick={() => {
+                        selectpersona(deckcard.cardid);
+                      }}
+                      activeCard={false}
+                      player={Genericplayer}
+                      showplayer={false}
+                    />
+                  </div>
+                );
+              })}
+            </div>
           </div>
-        </div>
-        <div className="cardpicker">
+          <div className="cardpicker">
           <div className="currentdeck">
             {FullDeck.cards.map((deckcard) => {
               return (
@@ -309,6 +346,7 @@ const DeckEditor = ({ deckid }: { deckid: string }) => {
               );
             })}
           </div>
+        </div>
         </div>
       </div>
     );

--- a/client/Pages/DeckVisual.tsx
+++ b/client/Pages/DeckVisual.tsx
@@ -26,7 +26,7 @@ export function CreateDeckVisual(
           canClick={true}
           doClick={() => {
             console.log("Clicked");
-            gotodeck;
+            gotodeck();
           }}
           activeCard={false}
           player={player}

--- a/client/style/editor.css
+++ b/client/style/editor.css
@@ -130,15 +130,38 @@
 
   overflow-y: scroll;
 }
+.deckname {
+  border: 1px solid white;
+  border-radius: 1em;
+  display: inline-block;
+  margin-left: 1em;
+}
+.deleteDeck {
+  border: 1px solid white;
+  border-radius: 1em;
+  float:right;
+  margin-right: 1em;
+}
+.deckEditorInner {
+  margin-top: 1em;
+  width: 50rem;
+}
+.deckEditorTopBanner {
+  height: 2em;
+  width: 100%;
+}
 .personapicker {
   border: 1px solid white;
   border-radius: 1em;
   padding: 1em;
+  width: 13rem;
+  display: inline-block;
 }
 .cardpicker {
   border: 1px solid white;
   border-radius: 1em;
   padding: 1em;
+  display: inline-block;
 }
 
 .currentpersona {

--- a/client/style/editor.css
+++ b/client/style/editor.css
@@ -130,15 +130,16 @@
 
   overflow-y: scroll;
 }
-.deckname {
+.deckName {
   border: 1px solid white;
   border-radius: 1em;
   display: inline-block;
-  margin-left: 1em;
+  height: 1.5em;
+  vertical-align: middle;
+  margin: 5px;
 }
 .deleteDeck {
-  border: 1px solid white;
-  border-radius: 1em;
+
   float:right;
   margin-right: 1em;
 }
@@ -156,6 +157,7 @@
   padding: 1em;
   width: 13rem;
   display: inline-block;
+  vertical-align: top;
 }
 .cardpicker {
   border: 1px solid white;
@@ -164,6 +166,12 @@
   display: inline-block;
 }
 
+.deckEditorButton {
+  font-size: 0.7em;
+  padding: 4px;
+  border: 1px solid white;
+  border-radius: 1em;
+}
 .currentpersona {
   border: 1px solid white;
   border-radius: 1em;

--- a/server/DbWrapper.ts
+++ b/server/DbWrapper.ts
@@ -54,6 +54,13 @@ function GetFullDeck(...args) {
   }
   return dbmod.GetFullDeck(...args);
 }
+function DeleteDeck(...args) {
+  if (isClient) {
+    return undefined;
+  }
+  return dbmod.DeleteDeck(...args);
+}
+
 function GetOwnedCards(...args) {
   if (isClient) {
     return undefined;
@@ -84,6 +91,7 @@ export {
   GetPlayer,
   GetOwnedCards,
   GetFullDeck,
+  DeleteDeck,
   GetPlayerIdFromName,
   LoadJsonDeck,
   DbDeckCard,

--- a/server/manage.ts
+++ b/server/manage.ts
@@ -392,6 +392,12 @@ Manage.get("/decks/get/:deckid", (ctx, next) => {
   const deckid = ctx.params.deckid;
   ctx.body = { deckid: deckid, decks: GetFullDeck(deckid) };
 });
+Manage.del("/decks/delete/:deckid", (ctx, next) => {
+  const deckid = ctx.params.deckid;
+  DeleteDeck(deckid);
+  ctx.body = { success: true };
+  return true;
+});
 Manage.get("/decks/create/:playerid", (ctx, next) => {
   const newdeckid = nanoid();
   const newemptydeck = NewEmptyDeck(ctx.params.playerid, newdeckid);


### PR DESCRIPTION
1. Fixed a minor bug which prevented multiple decks being created
2. Added a delete deck button and wired it into the db call
3. Prevented deleting a deck if it is your current selected deck. We might not want this however i suspect it will cause issues in quite a few places if we allow this, doing it this way means that we dont have to add checks elsewhere that the player has a selected deck
4. Rearranged the styling on the deck editor page to fit the delete deck button in however i've left most of the styling as i'm not sure what you'd like that page to look like. With my changes it looks like this:

![image](https://github.com/GiantRobotClub/CMCNew/assets/9598212/d2e445a0-20c4-40a0-b951-aa9c9ae7cde7)
