### PR TITLE
Fixed the gameover screen

### DIFF
--- a/client/CMCComponents/Board.tsx
+++ b/client/CMCComponents/Board.tsx
@@ -1,6 +1,6 @@
 import React, { CSSProperties, useState, MouseEvent, useEffect } from "react";
 import CMCCardVisual from "./Card";
-import { CMCGameState } from "../../shared/CardmasterGame";
+import { CMCGameState, CMCProps } from "../../shared/CardmasterGame";
 import type { BoardProps } from "boardgame.io/react";
 import { CanClickCard, OwnerOf } from "../../shared/LogicFunctions";
 import { CardType, ClickType } from "../../shared/Constants";
@@ -12,21 +12,11 @@ import { icons } from "./Icons";
 import useMousePosition from "./UseMousePosition";
 import { DbFullDeck } from "../../server/DbTypes";
 import Chat from "./Chat";
-
-interface CMCProps extends BoardProps<CMCGameState> {
-  // Additional custom properties for your component
-
-  goesfirst?: string;
-  dbplayerid?: string;
-  cpuopponent?: string;
-  showChat?: boolean;
-}
+import GameOver from "./GameOver";
 
 export function CMCBoard(props: CMCProps) {
   const [GameStarted, setGameStarted] = useState(false);
   const [Waiting, setWaiting] = useState(false);
-  const [winner, setWinner] = useState("");
-  const [rewards, setRewards] = useState([""]);
   const [dbid, setdbid] = useState("");
   const mousePosition = useMousePosition();
   if (props.G.wait == false && !GameStarted) {
@@ -170,49 +160,19 @@ export function CMCBoard(props: CMCProps) {
   }
 
   let otherPlayer = you == "0" ? "1" : "0";
+  
 
-  if (props.ctx.gameover) {
-    if (props.ctx.gameover.winner) {
-      setWinner(props.ctx.gameover.winner);
-      if (props.ctx.gameover.winner == you) {
-        //display win
-      }
-    } else {
-      // display loss
-    }
-    const requestOptions = {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        playeriD: dbid,
-        victory: {
-          type: "",
-          victory: props.ctx.gameover.winner == you,
-        },
-      }),
-    };
-    fetch("/api/manage/mats/give/", requestOptions)
-      .then((response) => response.json())
-      .then((data) => {
-        if (data.letterawards) {
-          setRewards(data.letterrewards);
-        }
-        if (data.cardawards) {
-          // todo
-        }
-      });
-
+  if (props.ctx.gameover && props.ctx.gameover.winner) {
     return (
-      <div className="winner">
-        {winner == you ? "You won :)" : "you lost :("}
-        <div className="rewards">
-          REWARDS:
-          {rewards.map((reward) => {
-            return <div className="reward">{icons["letter" + reward]}</div>;
-          })}
-        </div>
+    <div> 
+    <GameOver
+        props = {props}
+        winner = {props.ctx.gameover.winner}
+        player = {you}
+        dbid = {dbid}
+      />
       </div>
-    );
+    )
   } else {
     return (
       <div className="cmcboard">

--- a/client/CMCComponents/GameOver.tsx
+++ b/client/CMCComponents/GameOver.tsx
@@ -1,0 +1,54 @@
+import React, { useState, useEffect } from "react";
+import { icons } from "./Icons";
+import { useNavigate } from "react-router-dom";
+
+function GameOver({props, winner, player, dbid }) {
+    const [rewards, setRewards] = useState<any[]>([]);
+    const nav = useNavigate();
+
+    const requestOptions = {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+        playeriD: dbid,
+        victory: {
+        type: "",
+        victory: props.ctx.gameover.winner == player,
+        },
+    })};
+
+    useEffect(() => {
+        fetch("/api/manage/mats/give/", requestOptions)
+            .then((response) => response.json())
+            .then((data) => {
+            if (data.letterrewards) {
+                setRewards(data.letterrewards);
+            }
+            if (data.cardawards) {
+                // todo
+            }
+        })
+    }, []);
+      
+    return (
+    <div className="winner">
+        {winner == player ? "You won :)" : "you lost :("}
+        <div className="rewards">
+            REWARDS:
+            {rewards.map((reward, index) => {
+                return <div key={index} className="reward">{icons["letter" + reward.toLowerCase()]}</div>;
+            })}
+        </div>
+        <div>
+            <a onClick={() => nav("/home")}>Back to home</a>
+        </div>
+        
+    </div>
+
+
+    
+    );
+  
+}
+
+export default GameOver;

--- a/client/Pages/DeckChooser.tsx
+++ b/client/Pages/DeckChooser.tsx
@@ -107,28 +107,35 @@ const DeckChooser = () => {
     );
   }
   return (
-    <div id="deckchooser">
-      {Decks.map((deck: decklistdefinition) => {
-        const player = CreateDefaultPlayer(PlayerID);
-        player.name = deck.deckname;
-        return (
-          <div className="verticaldeckslice">
-            <div className="selected">
-              {DbPlayer.selecteddeck == deck.deckid
-                ? selected
-                : notselected(deck.deckid)}
+    <div>
+      <div id="deckchooser">
+        {Decks.map((deck: decklistdefinition) => {
+          const player = CreateDefaultPlayer(PlayerID);
+          player.name = deck.deckname;
+          return (
+            <div className="verticaldeckslice">
+              <div className="selected">
+                {DbPlayer.selecteddeck == deck.deckid
+                  ? selected
+                  : notselected(deck.deckid)}
+              </div>
+              <div className="deckvis" onClick={() => gotodeck(deck.deckid)}>
+                {CreateDeckVisual(player, deck, () => gotodeck(deck.deckid))}
+              </div>
             </div>
-            <div className="deckvis" onClick={() => gotodeck(deck.deckid)}>
-              {CreateDeckVisual(player, deck, () => gotodeck(deck.deckid))}
-            </div>
-          </div>
-        );
-      })}{" "}
-      <div className="verticaldeckslice">
-        <div className="selected"></div>
-        {emptydeckvisual}
+          );
+        })}{" "}
+        <div className="verticaldeckslice">
+          <div className="selected"></div>
+          {emptydeckvisual}
+        </div>
+      </div>
+      <div className="deckBackToHome">
+        <a onClick={() => nav("/home")}>Back to home</a>
       </div>
     </div>
+
+    
   );
 };
 

--- a/client/Pages/Home.tsx
+++ b/client/Pages/Home.tsx
@@ -100,7 +100,7 @@ function Home() {
           <div className="play-description">Manage your decks.</div>
         </Link>
       </div>
-      <SessionHandler />;
+      <SessionHandler />
     </div>
   );
 }

--- a/client/style/editor.css
+++ b/client/style/editor.css
@@ -424,3 +424,11 @@
 .enemyselector .enemyportrait.uncompleted {
   transform: scale(1.2);
 }
+
+.deckBackToHome {
+  text-align: center;
+}
+
+a.deckBackToHome {
+  display: block;
+}

--- a/shared/CardmasterGame.ts
+++ b/shared/CardmasterGame.ts
@@ -2,6 +2,7 @@ import { INVALID_MOVE } from "boardgame.io/core";
 import type { Ctx, Game, Move } from "boardgame.io";
 import { Stage, TurnOrder } from "boardgame.io/core";
 import premadeDecks from "../shared/data/premade.json";
+import type { BoardProps } from "boardgame.io/react";
 import {
   CMCCard,
   CMCLocationCard,
@@ -106,7 +107,7 @@ export interface CMCGameState {
   activeAbility?: Ability;
   activeCard?: CMCCard;
   returnStage: Stages[];
-  loser?: string;
+  winner?: string;
   location: CMCLocationCard;
   didinitialsetup: boolean;
   combat?: CMCCombat;
@@ -115,6 +116,15 @@ export interface CMCGameState {
   lastAbilityStack: StackedAbility[];
   wait: boolean;
   gamemode: GameMode;
+}
+
+export interface CMCProps extends BoardProps<CMCGameState> {
+  // Additional custom properties for your component
+
+  goesfirst?: string;
+  dbplayerid?: string;
+  cpuopponent?: string;
+  showChat?: boolean;
 }
 
 // Initial game state
@@ -417,7 +427,7 @@ export const CardmasterConflict: Game<CMCGameState> = {
           );
           if (!okay) {
             console.log("player lost due to draw out during inital setup");
-            G.loser = playerno;
+            G.winner = OtherPlayer(playerno);
           }
           PlayerAddResource(playerno, player.persona.startingResource, G);
         }
@@ -462,7 +472,7 @@ export const CardmasterConflict: Game<CMCGameState> = {
   },
   endIf: ({ G, ctx }) => {
     if (IsVictory(G)) {
-      return { winner: ctx.currentPlayer };
+      return { winner: G.winner };
     }
     if (IsDraw(G)) {
       return { draw: true };
@@ -472,10 +482,10 @@ export const CardmasterConflict: Game<CMCGameState> = {
   ai: ai,
 };
 
-// something has set the loser flag.
+// something has set the winner flag.
 function IsVictory(G: CMCGameState) {
-  if (G.loser) {
-    return { winner: OtherPlayer(G.loser) };
+  if (G.winner) {
+    return true;
   }
   return false;
 }

--- a/shared/LogicFunctions.ts
+++ b/shared/LogicFunctions.ts
@@ -21,7 +21,7 @@ import {
   Random,
   RandomAPI,
 } from "boardgame.io/dist/types/src/plugins/random/random";
-import { GetActivePlayer, GetActiveStage } from "./Util";
+import { GetActivePlayer, GetActiveStage, OtherPlayer } from "./Util";
 import { CanActivateAbility, TriggerCard, TriggerNames } from "./Abilities";
 import { EventsAPI } from "boardgame.io/dist/types/src/plugins/plugin-events";
 import { AbilityFunctionArgs } from "./CardFunctions";
@@ -536,8 +536,8 @@ function CanClickCard(
         return false;
       }
       const monster = card as CMCMonsterCard;
-      if (monster.dizzy) {
-        // cant attack when dizzy
+      if (monster.dizzy || monster.destroyed) {
+        // cant attack when dizzy or destroyed
         return false;
       }
       // is the monster already attacking?
@@ -666,7 +666,7 @@ function CheckState(G: CMCGameState) {
     const player: CMCPlayer = G.playerData[playerid];
     if (player.resources.intrinsic.health <= 0) {
       console.log("player lost due to health");
-      G.loser = playerid;
+      G.winner = OtherPlayer(playerid);
     }
     // set player deck values for visual reasons
     player.currentDeck = G.secret.decks[playerid].length;

--- a/shared/Moves.ts
+++ b/shared/Moves.ts
@@ -88,7 +88,7 @@ const passStage: Move<CMCGameState> = ({ G, ctx, events, random }) => {
 
     if (!okay) {
       console.log("player lost due to draw out at beginning of stage");
-      G.loser = activePlayer;
+      G.winner = OtherPlayer(activePlayer);
     }
 
     events.endStage();


### PR DESCRIPTION
Various changes mainly around fixing the gameover screen

- Fixed a few typos in the property names of the game over logic
- Moved the game over logic into its own component (This helps with some of the unnecessary re-rendering of the board component)
- Correct inconsistencies between looking at 'loser' and 'winner' of the game. The code is now always updating and looking at the winner property
- Prevented destroyed monsters attacking from the graveyard
- Added a 'Back to home' link on the game over screen as well as on the deck selection screen

![image](https://github.com/user-attachments/assets/299a9740-8f22-43f8-9482-17b61bc9974a)
![image](https://github.com/user-attachments/assets/7578ce42-574b-4946-9f70-72d6f63267df)
